### PR TITLE
feat: remove postgres k8s service - go direct

### DIFF
--- a/helm/ffc-ahwr-application/templates/postgres-service.yaml
+++ b/helm/ffc-ahwr-application/templates/postgres-service.yaml
@@ -1,5 +1,0 @@
-{{- if .Values.postgresService.postgresExternalName }}
-{{- include "ffc-helm-library.postgres-service" (list . "ffc-ahwr-application.postgres-service") -}}
-{{- end }}
-{{- define "ffc-ahwr-application.postgres-service" -}}
-{{- end -}}

--- a/helm/ffc-ahwr-application/values.yaml
+++ b/helm/ffc-ahwr-application/values.yaml
@@ -51,11 +51,7 @@ container:
 
 postgresService:
   postgresDb: ffc_ahwr_application
-  # postgresExternalName is the external host name to which PostgreSQL
-  # requests should be forwarded. If empty, PostgreSQL is assumed to be
-  # within the cluster and accessible via postgresHost
-  postgresExternalName:
-  postgresHost: ffc-ahwr-application-postgres
+  postgresExternalName: namespace.postgres.database.azure.com
   postgresPort: 5432
   postgresSchema: public
   postgresUser: postgres

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Application manager for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-application",
   "main": "app/index.js",


### PR DESCRIPTION
Rather than use the postgres k8s service the application does directly the sass DB when deployed via helm. This change removes code no longer needed.