### PR TITLE
fix: Allow vets to resubmit data

### DIFF
--- a/app/messaging/process-vet-visit.js
+++ b/app/messaging/process-vet-visit.js
@@ -18,8 +18,8 @@ const processVetVisit = async (message) => {
       return sendMessage({ applicationState: states.notFound }, vetVisitResponseMsgType, applicationResponseQueue, { sessionId })
     }
 
-    if (farmerApplication?.vetVisit?.dataValues) {
-      return sendMessage({ applicationState: states.alreadySubmitted }, vetVisitResponseMsgType, applicationResponseQueue, { sessionId })
+    if (farmerApplication?.claimed) {
+      return sendMessage({ applicationState: states.alreadyClaimed }, vetVisitResponseMsgType, applicationResponseQueue, { sessionId })
     }
 
     await set({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Application manager for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-application",
   "main": "app/index.js",

--- a/test/unit/app/messaging/process-vet-visit.test.js
+++ b/test/unit/app/messaging/process-vet-visit.test.js
@@ -24,7 +24,8 @@ applicationRepository.get.mockResolvedValueOnce({
     dataValues: {
       reference: 'VV-1234-5678'
     }
-  }
+  },
+  claimed: true
 }).mockRejectedValueOnce(error)
 
 describe(('Store data in database'), () => {
@@ -75,12 +76,12 @@ describe(('Store data in database'), () => {
     expect(sendVetConfirmationEmail).toHaveBeenCalledTimes(0)
   })
 
-  test('Do not store application if already submitted', async () => {
+  test('Do not store application if already claimed', async () => {
     await processVetVisit(message)
 
     expect(vetVisitRepository.set).toHaveBeenCalledTimes(0)
     expect(sendMessage).toHaveBeenCalledTimes(1)
-    expect(sendMessage).toHaveBeenCalledWith({ applicationState: states.alreadySubmitted }, vetVisitResponseMsgType, applicationResponseQueue, { sessionId })
+    expect(sendMessage).toHaveBeenCalledWith({ applicationState: states.alreadyClaimed }, vetVisitResponseMsgType, applicationResponseQueue, { sessionId })
     expect(sendFarmerClaimInvitationEmail).toHaveBeenCalledTimes(0)
     expect(sendVetConfirmationEmail).toHaveBeenCalledTimes(0)
   })


### PR DESCRIPTION
Currently, once a vet has submitted the record for the reference number they are not able to re-enter the journey again to login. This is due to validation on the reference number, it is checked to see if it has been submitted. If it has, an error message is displayed and no further progress can be made. The validation was put in place as there was an understanding once the record had been submitted it should not be editable.

However, potentially a vet will need to alter the information they have submitted and so the easiest way to do that is to remove the restrictions.

https://eaflood.atlassian.net/browse/VVAHWR-371