### PR TITLE
FFC-152234: allow for processing a new application even if for given SBI it already existed but only if it was not_agreed or withdrawn

### DIFF
--- a/app/constants/application-status.js
+++ b/app/constants/application-status.js
@@ -1,8 +1,8 @@
 module.exports = {
-  withdrawn: 2,
+  agreed: 1,
   inCheck: 5,
   notAgreed: 7,
   readyToPay: 9,
   rejected: 10,
-  agreed: 1
+  withdrawn: 2
 }

--- a/app/constants/application-status.js
+++ b/app/constants/application-status.js
@@ -3,5 +3,6 @@ module.exports = {
   inCheck: 5,
   notAgreed: 7,
   readyToPay: 9,
-  rejected: 10
+  rejected: 10,
+  agreed: 1
 }

--- a/app/constants/application-status.js
+++ b/app/constants/application-status.js
@@ -1,6 +1,7 @@
 module.exports = {
+  withdrawn: 2,
   inCheck: 5,
-  rejected: 10,
+  notAgreed: 7,
   readyToPay: 9,
-  withdrawn: 2
+  rejected: 10
 }

--- a/app/messaging/application/process-application.js
+++ b/app/messaging/application/process-application.js
@@ -21,9 +21,11 @@ const processApplication = async (msg) => {
       applicationData.organisation.sbi
     )
     if (
+      existingApplication &&
       existingApplication.statusId !== applicationStatus.withdrawn &&
       existingApplication.statusId !== applicationStatus.notAgreed
     ) {
+      console.log(existingApplication)
       existingApplicationReference = existingApplication.dataValues.reference
       throw Object.assign(
         new Error(

--- a/app/messaging/application/process-application.js
+++ b/app/messaging/application/process-application.js
@@ -25,7 +25,6 @@ const processApplication = async (msg) => {
       existingApplication.statusId !== applicationStatus.withdrawn &&
       existingApplication.statusId !== applicationStatus.notAgreed
     ) {
-      console.log(existingApplication)
       existingApplicationReference = existingApplication.dataValues.reference
       throw Object.assign(
         new Error(

--- a/app/messaging/application/process-application.js
+++ b/app/messaging/application/process-application.js
@@ -1,5 +1,6 @@
 const util = require('util')
 const states = require('./states')
+const applicationStatus = require('../../constants/application-status')
 const { applicationResponseMsgType, applicationResponseQueue } = require('../../config')
 const { sendFarmerConfirmationEmail } = require('../../lib/send-email')
 const sendMessage = require('../send-message')
@@ -19,7 +20,10 @@ const processApplication = async (msg) => {
     const existingApplication = await applicationRepository.getBySbi(
       applicationData.organisation.sbi
     )
-    if (existingApplication) {
+    if (
+      existingApplication.statusId !== applicationStatus.withdrawn &&
+      existingApplication.statusId !== applicationStatus.notAgreed
+    ) {
       existingApplicationReference = existingApplication.dataValues.reference
       throw Object.assign(
         new Error(

--- a/app/repositories/application-repository.js
+++ b/app/repositories/application-repository.js
@@ -77,7 +77,7 @@ async function getLatestApplicationsBy (businessEmail) {
 }
 
 /**
- * Get application by Single Business Identifier (SBI)
+ * Get the latest application by Single Business Identifier (SBI) number.
  *
  * @param {number} sbi
  * @returns application object.
@@ -86,7 +86,9 @@ async function getBySbi (sbi) {
   return models.application.findOne({
     where: {
       'data.organisation.sbi': sbi
-    }
+    },
+    order: [['createdAt', 'DESC']],
+    raw: true
   })
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "0.30.2",
+  "version": "0.31.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-application",
-      "version": "0.30.2",
+      "version": "0.31.2",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "^2.0.4",
@@ -2098,9 +2098,9 @@
       }
     },
     "node_modules/@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
@@ -11518,9 +11518,9 @@
       }
     },
     "@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
     },
     "@sideway/pinpoint": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "description": "Application manager for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-application",
   "main": "app/index.js",

--- a/test/unit/app/messaging/application/process-application.test.js
+++ b/test/unit/app/messaging/application/process-application.test.js
@@ -1,14 +1,7 @@
 const { when, resetAllWhenMocks } = require('jest-when')
-
-jest.mock('../../../../../app/lib/send-email')
 const { sendFarmerConfirmationEmail } = require('../../../../../app/lib/send-email')
-
-jest.mock('../../../../../app/messaging/send-message')
 const sendMessage = require('../../../../../app/messaging/send-message')
-
-jest.mock('../../../../../app/repositories/application-repository')
 const applicationRepository = require('../../../../../app/repositories/application-repository')
-
 const { applicationResponseMsgType, applicationResponseQueue } = require('../../../../../app/config')
 const states = require('../../../../../app/messaging/application/states')
 const processApplication = require('../../../../../app/messaging/application/process-application')
@@ -18,6 +11,10 @@ const consoleErrorSpy = jest.spyOn(console, 'error')
 
 const MOCK_REFERENCE = 'MOCK_REFERENCE'
 const MOCK_NOW = new Date()
+
+jest.mock('../../../../../app/lib/send-email')
+jest.mock('../../../../../app/messaging/send-message')
+jest.mock('../../../../../app/repositories/application-repository')
 
 describe(('Store application in database'), () => {
   const sessionId = '8e5b5789-dad5-4f16-b4dc-bf6db90ce090'
@@ -49,10 +46,9 @@ describe(('Store application in database'), () => {
     resetAllWhenMocks()
   })
 
-  const reference = '23D13'
   test('successfully submits application', async () => {
     applicationRepository.set.mockResolvedValue({
-      dataValues: { reference }
+      dataValues: { reference: MOCK_REFERENCE }
     })
     applicationRepository.getBySbi.mockResolvedValue()
 
@@ -67,7 +63,7 @@ describe(('Store application in database'), () => {
       statusId: applicationStatus.agreed
     }))
     expect(sendMessage).toHaveBeenCalledTimes(1)
-    expect(sendMessage).toHaveBeenCalledWith({ applicationState: states.submitted, applicationReference: reference }, applicationResponseMsgType, applicationResponseQueue, { sessionId })
+    expect(sendMessage).toHaveBeenCalledWith({ applicationState: states.submitted, applicationReference: MOCK_REFERENCE }, applicationResponseMsgType, applicationResponseQueue, { sessionId })
   })
 
   describe('Submits an existing application', () => {
@@ -114,10 +110,10 @@ describe(('Store application in database'), () => {
         statusId: applicationStatus.agreed
       }))
       expect(sendMessage).toHaveBeenCalledTimes(1)
-      expect(sendMessage).toHaveBeenCalledWith({ applicationState: states.submitted, applicationReference: reference }, applicationResponseMsgType, applicationResponseQueue, { sessionId })
+      expect(sendMessage).toHaveBeenCalledWith({ applicationState: states.submitted, applicationReference: MOCK_REFERENCE }, applicationResponseMsgType, applicationResponseQueue, { sessionId })
     })
 
-    test('submits an existing application with statusId 1', async () => {
+    test(' with statusId 1 (agreed)', async () => {
       when(applicationRepository.getBySbi)
         .calledWith(
           message.body.organisation.sbi
@@ -160,7 +156,7 @@ describe(('Store application in database'), () => {
     const MOCK_REFERENCE = 'MOCK_REFERENCE'
     const MOCK_NOW = new Date()
     applicationRepository.set.mockResolvedValue({
-      dataValues: { reference }
+      dataValues: { reference: MOCK_REFERENCE }
     })
     when(applicationRepository.getBySbi)
       .calledWith(
@@ -182,7 +178,7 @@ describe(('Store application in database'), () => {
     const MOCK_NOW = new Date()
 
     applicationRepository.set.mockResolvedValue({
-      dataValues: { reference }
+      dataValues: { reference: MOCK_REFERENCE }
     })
     when(applicationRepository.getBySbi)
       .calledWith(
@@ -207,12 +203,12 @@ describe(('Store application in database'), () => {
       statusId: applicationStatus.agreed
     }))
     expect(sendMessage).toHaveBeenCalledTimes(1)
-    expect(sendMessage).toHaveBeenCalledWith({ applicationState: states.submitted, applicationReference: reference }, applicationResponseMsgType, applicationResponseQueue, { sessionId })
+    expect(sendMessage).toHaveBeenCalledWith({ applicationState: states.submitted, applicationReference: MOCK_REFERENCE }, applicationResponseMsgType, applicationResponseQueue, { sessionId })
   })
 
   test('successfully submits rejected application', async () => {
     applicationRepository.set.mockResolvedValue({
-      dataValues: { reference }
+      dataValues: { reference: MOCK_REFERENCE }
     })
 
     message.body.offerStatus = 'rejected'
@@ -227,7 +223,7 @@ describe(('Store application in database'), () => {
       statusId: applicationStatus.notAgreed
     }))
     expect(sendMessage).toHaveBeenCalledTimes(1)
-    expect(sendMessage).toHaveBeenCalledWith({ applicationState: states.submitted, applicationReference: reference }, applicationResponseMsgType, applicationResponseQueue, { sessionId })
+    expect(sendMessage).toHaveBeenCalledWith({ applicationState: states.submitted, applicationReference: MOCK_REFERENCE }, applicationResponseMsgType, applicationResponseQueue, { sessionId })
     expect(sendFarmerConfirmationEmail).toHaveBeenCalledTimes(0)
   })
 

--- a/test/unit/app/messaging/application/process-application.test.js
+++ b/test/unit/app/messaging/application/process-application.test.js
@@ -41,17 +41,19 @@ describe(('Store application in database'), () => {
     sessionId
   }
 
+  beforeEach(() => {
+    applicationRepository.set.mockResolvedValue({
+      dataValues: { reference: MOCK_REFERENCE }
+    })
+    applicationRepository.getBySbi.mockResolvedValue()
+  })
+
   afterEach(() => {
     jest.clearAllMocks()
     resetAllWhenMocks()
   })
 
   test('successfully submits application', async () => {
-    applicationRepository.set.mockResolvedValue({
-      dataValues: { reference: MOCK_REFERENCE }
-    })
-    applicationRepository.getBySbi.mockResolvedValue()
-
     await processApplication(message)
 
     expect(applicationRepository.set).toHaveBeenCalledTimes(1)
@@ -184,7 +186,7 @@ describe(('Store application in database'), () => {
   })
 
   test('Application submission message validation failed', async () => {
-    delete message.body.organisation.isTest
+    delete message.body.organisation.email
     await processApplication(message)
     expect(sendFarmerConfirmationEmail).toHaveBeenCalledTimes(0)
     expect(sendMessage).toHaveBeenCalledTimes(1)

--- a/test/unit/app/messaging/application/process-application.test.js
+++ b/test/unit/app/messaging/application/process-application.test.js
@@ -114,7 +114,9 @@ describe(('Store application in database'), () => {
   test('submits an existing application with statusId 2', async () => {
     const MOCK_REFERENCE = 'MOCK_REFERENCE'
     const MOCK_NOW = new Date()
-
+    applicationRepository.set.mockResolvedValue({
+      dataValues: { reference }
+    })
     when(applicationRepository.getBySbi)
       .calledWith(
         message.body.organisation.sbi
@@ -127,13 +129,15 @@ describe(('Store application in database'), () => {
         statusId: WITHDRAWN
       })
 
+    await processApplication(message)
+
     expect(applicationRepository.set).toHaveBeenCalledTimes(1)
     expect(applicationRepository.set).toHaveBeenCalledWith(expect.objectContaining({
       reference: '',
       data: message.body,
       createdBy: 'admin',
       createdAt: expect.any(Date),
-      statusId: WITHDRAWN
+      statusId: AGREED
     }))
     expect(sendMessage).toHaveBeenCalledTimes(1)
     expect(sendMessage).toHaveBeenCalledWith({ applicationState: states.submitted, applicationReference: reference }, applicationResponseMsgType, applicationResponseQueue, { sessionId })
@@ -143,6 +147,9 @@ describe(('Store application in database'), () => {
     const MOCK_REFERENCE = 'MOCK_REFERENCE'
     const MOCK_NOW = new Date()
 
+    applicationRepository.set.mockResolvedValue({
+      dataValues: { reference }
+    })
     when(applicationRepository.getBySbi)
       .calledWith(
         message.body.organisation.sbi
@@ -155,13 +162,15 @@ describe(('Store application in database'), () => {
         statusId: NOT_AGREED
       })
 
+    await processApplication(message)
+
     expect(applicationRepository.set).toHaveBeenCalledTimes(1)
     expect(applicationRepository.set).toHaveBeenCalledWith(expect.objectContaining({
       reference: '',
       data: message.body,
       createdBy: 'admin',
       createdAt: expect.any(Date),
-      statusId: NOT_AGREED
+      statusId: AGREED
     }))
     expect(sendMessage).toHaveBeenCalledTimes(1)
     expect(sendMessage).toHaveBeenCalledWith({ applicationState: states.submitted, applicationReference: reference }, applicationResponseMsgType, applicationResponseQueue, { sessionId })

--- a/test/unit/app/messaging/application/process-application.test.js
+++ b/test/unit/app/messaging/application/process-application.test.js
@@ -152,60 +152,6 @@ describe(('Store application in database'), () => {
     })
   })
 
-  test('submits an existing application with statusId 2', async () => {
-    const MOCK_REFERENCE = 'MOCK_REFERENCE'
-    const MOCK_NOW = new Date()
-    applicationRepository.set.mockResolvedValue({
-      dataValues: { reference: MOCK_REFERENCE }
-    })
-    when(applicationRepository.getBySbi)
-      .calledWith(
-        message.body.organisation.sbi
-      )
-      .mockResolvedValue({
-        dataValues: {
-          reference: MOCK_REFERENCE,
-          createdAt: MOCK_NOW
-        },
-        statusId: applicationStatus.withdrawn
-      })
-
-    await processApplication(message)
-  })
-
-  test('submits an existing application with statusId 7', async () => {
-    const MOCK_REFERENCE = 'MOCK_REFERENCE'
-    const MOCK_NOW = new Date()
-
-    applicationRepository.set.mockResolvedValue({
-      dataValues: { reference: MOCK_REFERENCE }
-    })
-    when(applicationRepository.getBySbi)
-      .calledWith(
-        message.body.organisation.sbi
-      )
-      .mockResolvedValue({
-        dataValues: {
-          reference: MOCK_REFERENCE,
-          createdAt: MOCK_NOW
-        },
-        statusId: applicationStatus.notAgreed
-      })
-
-    await processApplication(message)
-
-    expect(applicationRepository.set).toHaveBeenCalledTimes(1)
-    expect(applicationRepository.set).toHaveBeenCalledWith(expect.objectContaining({
-      reference: '',
-      data: message.body,
-      createdBy: 'admin',
-      createdAt: expect.any(Date),
-      statusId: applicationStatus.agreed
-    }))
-    expect(sendMessage).toHaveBeenCalledTimes(1)
-    expect(sendMessage).toHaveBeenCalledWith({ applicationState: states.submitted, applicationReference: MOCK_REFERENCE }, applicationResponseMsgType, applicationResponseQueue, { sessionId })
-  })
-
   test('successfully submits rejected application', async () => {
     applicationRepository.set.mockResolvedValue({
       dataValues: { reference: MOCK_REFERENCE }

--- a/test/unit/app/repository/application-repository.test.js
+++ b/test/unit/app/repository/application-repository.test.js
@@ -538,7 +538,9 @@ describe('Application Repository test', () => {
     expect(data.models.application.findOne).toHaveBeenCalledWith({
       where: {
         'data.organisation.sbi': sbi
-      }
+      },
+      order: [['createdAt', 'DESC']],
+      raw: true
     })
   })
 

--- a/test/unit/app/repository/application-repository.test.js
+++ b/test/unit/app/repository/application-repository.test.js
@@ -532,7 +532,23 @@ describe('Application Repository test', () => {
   test('getBySbi', async () => {
     const sbi = 123456789
 
-    await repository.getBySbi(sbi)
+    when(data.models.application.findOne)
+      .calledWith({
+        where: {
+          'data.organisation.sbi': sbi
+        },
+        order: [['createdAt', 'DESC']],
+        raw: true
+      })
+      .mockResolvedValue({
+        application: 'MockApplication'
+      })
+
+    const result = await repository.getBySbi(sbi)
+
+    expect(result).toEqual({
+      application: 'MockApplication'
+    })
 
     expect(data.models.application.findOne).toHaveBeenCalledTimes(1)
     expect(data.models.application.findOne).toHaveBeenCalledWith({


### PR DESCRIPTION
Currently the logic in the application service will not allow a second application for the same SBI. However, this is incorrect as a withdrawn or not agreed application should allow another application for the same SBI to go ahead.

https://dev.azure.com/defragovuk/DEFRA-FFC/_sprints/taskboard/DEFRA-FFC%20Vet%20Visits%20Team/DEFRA-FFC/Vet%20Visits/Sprint%2024?workitem=152234