### PR TITLE
Bugfix/349307 unable to submit claim in old world when no orgemail exists

### DIFF
--- a/app/messaging/schema/submit-claim-schema.js
+++ b/app/messaging/schema/submit-claim-schema.js
@@ -26,7 +26,7 @@ const submitClaimSchema = joi.object({
       cph: joi.string().optional(),
       address: joi.string().required(),
       email: joi.string().required(),
-      orgEmail: joi.string().optional(),
+      orgEmail: joi.string().allow(null).optional().lowercase().email({ tlds: false }),
       isTest: joi.boolean().optional()
     })
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "0.44.46",
+  "version": "0.44.47",
   "description": "Application manager for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-application",
   "main": "app/index.js",


### PR DESCRIPTION
## Description of changes

<!-- What have you implemented in this PR? -->

## Checklist

<!-- [x] if you have completed the task -->
<!-- [n/a] if the task is not relevant -->

- [ ] Removed all unnecessary console logs
- [ ] Removed all commented out code
- [ ] Updated README / confluence
