### PR TITLE
fix(AHWR-204): Raise process-claim event for new world as well as old

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,16 +107,19 @@ A convenience script is provided to run automated tests in a containerised
 environment. This will rebuild images before running tests via docker compose,
 using a combination of `docker-compose.yaml` and `docker-compose.test.yaml`.
 The command given to `docker compose run` may be customised by passing
-arguments to the test script.
+arguments to the test script. ```(scripts/test)```
+Note that executing this script will load any .env
+file you have locally automatically which may affect test results. Please run
+testlocal instead which wraps this and temporarily moves any present .env file
 
 Examples:
 
 ```sh
 # Run all tests
-scripts/test
+scripts/testlocal
 
 # Run tests with file watch
-scripts/test -w
+scripts/testlocal -w
 ```
 
 ## CI pipeline

--- a/app/messaging/application/submit-claim.js
+++ b/app/messaging/application/submit-claim.js
@@ -58,7 +58,8 @@ const submitClaim = async (message) => {
           data,
           reference,
           status: statusId,
-          sbi: application.dataValues.data.organisation.sbi
+          sbi: application.dataValues.data.organisation.sbi,
+          scheme: 'old-world'
         }
       })
     } else {

--- a/app/routes/api/claim.js
+++ b/app/routes/api/claim.js
@@ -274,6 +274,19 @@ module.exports = [
 
         request.logger.setBindings({ claimConfirmationEmailSent })
 
+        if (claimConfirmationEmailSent) {
+          appInsights.defaultClient.trackEvent({
+            name: 'process-claim',
+            properties: {
+              data,
+              reference: claim?.dataValues?.reference,
+              status: statusId,
+              sbi,
+              scheme: 'new-world'
+            }
+          })
+        }
+
         return h.response(claim).code(200)
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "0.45.17",
+  "version": "0.45.18",
   "description": "Application manager for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-application",
   "main": "app/index.js",

--- a/scripts/testlocal
+++ b/scripts/testlocal
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+echo "Moving your .env file to .env.testtemp"
+mv .env .env.testtemp
+
+BASEDIR=$(dirname $0)
+$BASEDIR/test "$@"
+
+echo "Moving your .env file back as we're all done!"
+mv .env.testtemp .env


### PR DESCRIPTION
## Description of changes

fix(AHWR-204): Raise process-claim event for new world as well as old

Prior to this, the app was recording an event when a claim was processed fully for old world applications, but not for new world ones. This affects the dashboard used to track post-release success.

## Checklist

<!-- [x] if you have completed the task -->
<!-- [n/a] if the task is not relevant -->

- [ x] Removed all unnecessary console logs
- [x] Removed all commented out code
- [x ] Updated README / confluence
