### PR TITLE
fix(AHWR-365): return empty collections

### DIFF
--- a/app/routes/api/claim.js
+++ b/app/routes/api/claim.js
@@ -167,11 +167,7 @@ module.exports = [
       handler: async (request, h) => {
         const claims = await getByApplicationReference(request.params.ref)
 
-        if (claims.length) {
-          return h.response(claims).code(200)
-        } else {
-          return h.response('Not Found').code(404).takeover()
-        }
+        return h.response(claims).code(200)
       }
     }
   }, {

--- a/app/routes/api/contact-history.js
+++ b/app/routes/api/contact-history.js
@@ -17,11 +17,8 @@ module.exports = [
       },
       handler: async (request, h) => {
         const history = await contactHistoryRepository.getAllByApplicationReference(request.params.ref)
-        if (history.length) {
-          return h.response(history).code(200)
-        } else {
-          return h.response('Not Found').code(404).takeover()
-        }
+
+        return h.response(history).code(200)
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "0.45.26",
+  "version": "0.45.27",
   "description": "Application manager for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-application",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/api/claim.test.js
+++ b/test/integration/narrow/routes/api/claim.test.js
@@ -130,7 +130,7 @@ describe('Get claims test', () => {
     claimRepository.getByApplicationReference.mockResolvedValue(data)
 
     const { result } = await server.inject(options)
-    console.log(result)
+
     expect(result).toEqual(data)
   })
 

--- a/test/integration/narrow/routes/api/claim.test.js
+++ b/test/integration/narrow/routes/api/claim.test.js
@@ -61,13 +61,14 @@ describe('Get claims test', () => {
     expect(claimRepository.getByReference).toHaveBeenCalledTimes(1)
     expect(res.payload).toBe('Not Found')
   })
-  test('Get claims by application reference and return 200', async () => {
+
+  test('get-by-application-reference returns claims', async () => {
     const options = {
       method: 'GET',
       url: '/api/claim/get-by-application-reference/AHWR-0AD3-3322'
     }
 
-    claimRepository.getByApplicationReference.mockResolvedValue([
+    const data = [
       {
         id: '5602bac6-0812-42b6-bfb0-35f7ed2fd16c',
         reference: 'AHWR-5602-BAC6',
@@ -124,26 +125,28 @@ describe('Get claims test', () => {
           status: 'ON HOLD'
         }
       }
-    ])
+    ]
 
-    const res = await server.inject(options)
+    claimRepository.getByApplicationReference.mockResolvedValue(data)
 
-    expect(res.statusCode).toBe(200)
-    expect(claimRepository.getByApplicationReference).toHaveBeenCalledTimes(1)
+    const { result } = await server.inject(options)
+    console.log(result)
+    expect(result).toEqual(data)
   })
-  test('When application does not have any claims return 404', async () => {
+
+  test('get-by-application-reference returns empty claims array', async () => {
     const options = {
       method: 'GET',
       url: '/api/claim/get-by-application-reference/AHWR-5602-BAC6'
     }
 
-    claimRepository.getByApplicationReference.mockResolvedValue([])
+    const data = []
 
-    const res = await server.inject(options)
+    claimRepository.getByApplicationReference.mockResolvedValue(data)
 
-    expect(res.statusCode).toBe(404)
-    expect(claimRepository.getByApplicationReference).toHaveBeenCalledTimes(1)
-    expect(res.payload).toBe('Not Found')
+    const { result } = await server.inject(options)
+
+    expect(result).toEqual(data)
   })
 })
 

--- a/test/integration/narrow/routes/api/contact-history.test.js
+++ b/test/integration/narrow/routes/api/contact-history.test.js
@@ -19,12 +19,13 @@ describe('Update contact history test', () => {
   describe('GET contact history route', () => {
     const reference = 'ABC-1234'
     const url = `/api/application/contact-history/${reference}`
-    test('returns 200', async () => {
+
+    test('returns contact history', async () => {
       const options = {
         method: 'GET',
         url
       }
-      contactHistoryRepository.getAllByApplicationReference.mockResolvedValueOnce([
+      const data = [
         {
           dataValues: {
             id: '67f8930f-a674-4fff-998a-3e11317aa2be',
@@ -38,22 +39,28 @@ describe('Update contact history test', () => {
             updatedBy: null
           }
         }
-      ])
-      const res = await server.inject(options)
-      expect(res.statusCode).toBe(200)
-      expect(contactHistoryRepository.getAllByApplicationReference).toHaveBeenCalledTimes(1)
+      ]
+      contactHistoryRepository.getAllByApplicationReference.mockResolvedValueOnce(data)
+
+      const { result } = await server.inject(options)
+
+      expect(result).toEqual(data)
     })
-    test('returns 404', async () => {
+
+    test('returns empty history array', async () => {
       const options = {
         method: 'GET',
         url
       }
-      contactHistoryRepository.getAllByApplicationReference.mockResolvedValueOnce([])
-      const res = await server.inject(options)
-      expect(res.statusCode).toBe(404)
-      expect(contactHistoryRepository.getAllByApplicationReference).toHaveBeenCalledTimes(1)
+      const data = []
+      contactHistoryRepository.getAllByApplicationReference.mockResolvedValueOnce(data)
+
+      const { result } = await server.inject(options)
+
+      expect(result).toEqual(data)
     })
   })
+
   describe('PUT route', () => {
     test('Update email, orgEmail, farmerName and address fields in application and add the changed fields to contact history table', async () => {
       const options = {


### PR DESCRIPTION
The get claim by application reference and contact history endpoints now return an empty array [] instead of a 404 if there are no available records.

Notes for testing added to ticket: https://eaflood.atlassian.net/browse/AHWR-365