### PR TITLE
Fixed the error where we werent updating claims

### DIFF
--- a/app/routes/api/stage-execution.js
+++ b/app/routes/api/stage-execution.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { getClaimByReference } from '../../repositories/claim-repository.js'
+import { getClaimByReference, updateClaimByReference } from '../../repositories/claim-repository.js'
 import { applicationStatus } from '../../constants/index.js'
 import { getApplication, updateApplicationByReference } from '../../repositories/application-repository.js'
 import { getAll, set, getById, update, getByApplicationReference } from '../../repositories/stage-execution-repository.js'
@@ -23,7 +23,7 @@ export const stageExecutionHandlers = [{
   options: {
     handler: async (request, h) => {
       const stageExecutions = await getByApplicationReference(request.params.applicationReference)
-      console.log(`${stageExecutions ? stageExecutions.length : '0'}stage executions for ${request.params.applicationReference}`, stageExecutions)
+
       if (stageExecutions) {
         return h.response(stageExecutions).code(200)
       } else {
@@ -96,7 +96,9 @@ export const stageExecutionHandlers = [{
         if (request.payload.claimOrApplication === 'claim') {
           const mainApplication = await getApplication(application.dataValues.applicationReference)
           sbi = mainApplication?.dataValues?.data?.organisation?.sbi
-          await updateApplicationByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy, sbi })
+          // note that even though it using request.payload.applicationReference
+          // it can actually be the claim reference which is passed in the request
+          await updateClaimByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy, sbi })
         } else {
           await updateApplicationByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy })
         }

--- a/app/routes/api/stage-execution.js
+++ b/app/routes/api/stage-execution.js
@@ -93,10 +93,12 @@ export const stageExecutionHandlers = [{
 
       if (statusId) {
         if (request.payload.claimOrApplication === 'claim') {
+          const mainApplication = await getApplication(applicationOrClaim.dataValues.applicationReference)
+          const sbi = mainApplication?.dataValues?.data?.organisation?.sbi
           // note that even though it using request.payload.applicationReference
           // it can actually be the claim reference which is passed in the request
           // see AHWR-454 for further details
-          await updateClaimByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy })
+          await updateClaimByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy, sbi })
         } else {
           await updateApplicationByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy })
         }

--- a/app/routes/api/stage-execution.js
+++ b/app/routes/api/stage-execution.js
@@ -53,19 +53,18 @@ export const stageExecutionHandlers = [{
       }
     },
     handler: async (request, h) => {
-      let application
-      let sbi
+      let applicationOrClaim
       request.logger.setBindings({ payload: request.payload })
 
       if (request.payload.claimOrApplication === 'claim') {
-        application = await getClaimByReference(request.payload.applicationReference)
+        applicationOrClaim = await getClaimByReference(request.payload.applicationReference)
       }
 
       if (request.payload.claimOrApplication === 'application') {
-        application = await getApplication(request.payload.applicationReference)
+        applicationOrClaim = await getApplication(request.payload.applicationReference)
       }
 
-      if (!application?.dataValues) {
+      if (!applicationOrClaim?.dataValues) {
         return h.response('Reference not found').code(400).takeover()
       }
 
@@ -94,11 +93,10 @@ export const stageExecutionHandlers = [{
 
       if (statusId) {
         if (request.payload.claimOrApplication === 'claim') {
-          const mainApplication = await getApplication(application.dataValues.applicationReference)
-          sbi = mainApplication?.dataValues?.data?.organisation?.sbi
           // note that even though it using request.payload.applicationReference
           // it can actually be the claim reference which is passed in the request
-          await updateClaimByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy, sbi })
+          // see AHWR-454 for further details
+          await updateClaimByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy })
         } else {
           await updateApplicationByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy })
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "description": "Application manager for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-application",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/api/stage-execution.test.js
+++ b/test/integration/narrow/routes/api/stage-execution.test.js
@@ -4,6 +4,7 @@ import { getClaimByReference, updateClaimByReference } from '../../../../../app/
 import { getApplication, updateApplicationByReference } from '../../../../../app/repositories/application-repository'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { server } from '../../../../../app/server'
+import { applicationStatus } from '../../../../../app/constants'
 
 jest.mock('../../../../../app/repositories/stage-execution-repository')
 jest.mock('../../../../../app/repositories/application-repository')
@@ -109,11 +110,11 @@ describe('Stage execution test', () => {
 
   describe(`POST ${url} route`, () => {
     test.each([
-      { action: 'Ready to pay' },
-      { action: 'Rejected' },
-      { action: 'Recommend to pay' },
-      { action: 'Recommend to reject' }
-    ])('returns 200 when Recommend to pay', async ({ action }) => {
+      { action: 'Ready to pay', expectedStatusId: applicationStatus.readyToPay },
+      { action: 'Rejected', expectedStatusId: applicationStatus.rejected },
+      { action: 'Recommend to pay', expectedStatusId: applicationStatus.recommendToPay },
+      { action: 'Recommend to reject', expectedStatusId: applicationStatus.recommendToReject }
+    ])('returns 200 when Recommend to pay', async ({ action, expectedStatusId }) => {
       const mockGet = {
         dataValues: {
           id: 1,
@@ -140,7 +141,7 @@ describe('Stage execution test', () => {
       expect(res.statusCode).toBe(200)
       expect(set).toHaveBeenCalledTimes(1)
       expect(set).toHaveBeenCalledWith({ ...data, claimOrApplication: 'claim', action: { action }, executedAt: expect.any(Date) })
-      expect(updateClaimByReference).toHaveBeenCalledTimes(1)
+      expect(updateClaimByReference).toHaveBeenCalledWith({ reference: data.applicationReference, statusId: expectedStatusId, updatedBy: data.executedBy })
       expect(res.result).toEqual({ ...mockResponse, claimOrApplication: 'claim', action: { action } })
     })
     test('returns 200 when an application is Recommended to pay', async () => {
@@ -155,9 +156,9 @@ describe('Stage execution test', () => {
         }
       }
       when(getApplication).calledWith('AHWR-0000-0000').mockResolvedValue(mockGet)
-      when(set)
-        .calledWith({ ...data, executedAt: expect.any(Date) }, 123)
-        .mockResolvedValue(mockResponse)
+      // when(set)
+      //   .calledWith({ ...data, executedAt: expect.any(Date) }, 123)
+      //   .mockResolvedValue(mockResponse)
 
       const options = {
         method: 'POST',

--- a/test/integration/narrow/routes/api/stage-execution.test.js
+++ b/test/integration/narrow/routes/api/stage-execution.test.js
@@ -156,9 +156,6 @@ describe('Stage execution test', () => {
         }
       }
       when(getApplication).calledWith('AHWR-0000-0000').mockResolvedValue(mockGet)
-      // when(set)
-      //   .calledWith({ ...data, executedAt: expect.any(Date) }, 123)
-      //   .mockResolvedValue(mockResponse)
 
       const options = {
         method: 'POST',

--- a/test/integration/narrow/routes/api/stage-execution.test.js
+++ b/test/integration/narrow/routes/api/stage-execution.test.js
@@ -1,6 +1,6 @@
 import { ValidationError } from 'joi'
 import { getAll, getById, set, update, getByApplicationReference } from '../../../../../app/repositories/stage-execution-repository'
-import { getClaimByReference } from '../../../../../app/repositories/claim-repository'
+import { getClaimByReference, updateClaimByReference } from '../../../../../app/repositories/claim-repository'
 import { getApplication, updateApplicationByReference } from '../../../../../app/repositories/application-repository'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { server } from '../../../../../app/server'
@@ -140,10 +140,10 @@ describe('Stage execution test', () => {
       expect(res.statusCode).toBe(200)
       expect(set).toHaveBeenCalledTimes(1)
       expect(set).toHaveBeenCalledWith({ ...data, claimOrApplication: 'claim', action: { action }, executedAt: expect.any(Date) })
-      expect(updateApplicationByReference).toHaveBeenCalledTimes(1)
+      expect(updateClaimByReference).toHaveBeenCalledTimes(1)
       expect(res.result).toEqual({ ...mockResponse, claimOrApplication: 'claim', action: { action } })
     })
-    test('returns 200 when Recommend to pay', async () => {
+    test('returns 200 when an application is Recommended to pay', async () => {
       const mockGet = {
         dataValues: {
           id: 1,


### PR DESCRIPTION
When a stage execution change happened via backoffice, we werent updating the claim. This meant we couldnt move claims forward to recommend to pay. This change fixes that, and fixes the tests which ensure it happens.