### PR TITLE
Allow claim filtering ahwr 457

### DIFF
--- a/app/routes/api/claim.js
+++ b/app/routes/api/claim.js
@@ -195,7 +195,14 @@ export const claimHandlers = [
         }
       },
       handler: async (request, h) => {
-        const { total, claims } = await searchClaims(request.payload.search.text ?? '', request.payload.search.type, request.payload.offset, request.payload.limit, request.payload.sort)
+        const { search, filter, offset, limit, sort } = request.payload
+        const { total, claims } = await searchClaims(
+          search,
+          filter,
+          offset,
+          limit,
+          sort
+        )
         return h.response({ total, claims }).code(200)
       }
     }

--- a/app/routes/api/schema/search-payload.schema.js
+++ b/app/routes/api/schema/search-payload.schema.js
@@ -6,5 +6,10 @@ export const searchPayloadSchema = {
   search: Joi.object({
     text: Joi.string().valid().optional().allow(''),
     type: Joi.string().valid().optional().allow('')
+  }).optional(),
+  filter: Joi.object({
+    field: Joi.string().required(),
+    op: Joi.string().required(),
+    value: Joi.string().required()
   }).optional()
 }

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   env: {
-    development: {
+    test: {
       plugins: ['@babel/plugin-transform-modules-commonjs']
     }
   }

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -7,6 +7,8 @@ services:
   ffc-ahwr-application:
     build:
       target: development
+    environment:
+      NODE_ENV: test
     image: ffc-ahwr-application-development
     container_name: ffc-ahwr-application-test
     command: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "0.46.3",
+  "version": "0.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-application",
-      "version": "0.46.3",
+      "version": "0.47.0",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/data-tables": "^13.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "0.46.3",
+  "version": "0.47.0",
   "description": "Application manager for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-application",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:debug": "node --inspect-brk=0.0.0.0 ./node_modules/jest/bin/jest.js --coverage=false --onlyChanged --watch --runInBand --no-cache",
     "lint:fix": "standard --fix",
     "start:watch": "nodemon --inspect=0.0.0.0 --ext js --legacy-watch app/index.js",
-    "start:debug": "nodemon --inspect-brk=0.0.0.0 --ext js --legacy-watch app/index.js"
+    "start:debug": "nodemon --inspect-brk=0.0.0.0 --ext js --legacy-watch app/index.js",
+    "jest": "jest"
   },
   "author": "Defra",
   "contributors": [

--- a/test/unit/app/repository/claim-repository.test.js
+++ b/test/unit/app/repository/claim-repository.test.js
@@ -716,12 +716,19 @@ describe('Claim repository test', () => {
       { searchText: '113494460', searchType: 'sbi', sort: { field: 'sbi', direction: undefined } },
       { searchText: '113494460', searchType: 'sbi', sort: { field: 'sbi', direction: 'DECS' } },
       { searchText: '113494460', searchType: 'sbi', sort: undefined },
+      { searchText: 'AHWR-TEST-TEST', searchType: 'appRef' },
+      { searchType: 'adsdf' },
       { searchText: 'dfdf', searchType: 'adsdf', sort: undefined }
     ])('Search claim by search text $searchText, search type $searchType ', async ({ searchText, searchType, sort }) => {
       const callTimes = searchType !== 'adsdf' ? 1 : 0
       when(buildData.models.claim.count).mockResolvedValue(2)
       when(buildData.models.claim.findAll).mockResolvedValue(['claims1', 'claims2'])
-      await searchClaims(searchText, searchType, undefined, undefined, sort)
+      const search = {
+        text: searchText,
+        type: searchType
+      }
+      const filter = searchType === 'status' ? {} : undefined
+      await searchClaims(search, filter, undefined, undefined, sort)
 
       expect(buildData.models.claim.count).toHaveBeenCalledTimes(callTimes)
       expect(buildData.models.claim.findAll).toHaveBeenCalledTimes(callTimes)


### PR DESCRIPTION
Allow calls to the claim search to accept an optional filter property which will be applied to the DB query. This will allow the back-office cron job which updates claim statuses to fetch only claims that were last updated more than a day ago.

Filter has three properties:
**field:** db column to filter against
**op:** operator to apply (matches lte, lt, gt etc)
**value:** value to apply
 
**example filter:**
```javascript
{
  filter: {
    field: 'updatedAt',
    op: 'lte',
    value: '2025-01-15'
  }
}
```

**example curl:**
```sh
curl -X 'POST' \
  'http://localhost:3001/api/claim/search' \
  -H 'accept: application/json' \
  -H 'content-type: application/json' \
  --data-binary @- << EOF
{
  "search": {
    "text": "ON HOLD",
    "type": "status"
  },
  "filter": {
    "field": "updatedAt",
    "op": "lte",
    "value": "2025-01-14 09:18:00"
  }
}
EOF
```

Also set the test env to test because test.