### PR TITLE
improvement(AHWR-29): return empty history array

### DIFF
--- a/app/azure-storage/application-status-repository.js
+++ b/app/azure-storage/application-status-repository.js
@@ -10,6 +10,5 @@ export const getApplicationHistory = async (reference) => {
     odata`PartitionKey eq ${reference}`
   )
 
-  if (historyRecords.length === 0) { return null }
   return historyRecords
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Application manager for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-application",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/api/application-history.test.js
+++ b/test/integration/narrow/routes/api/application-history.test.js
@@ -31,7 +31,7 @@ describe('Application history test', () => {
 
     const options = {
       method: 'GET',
-      url: '/api/application/history/ABC-1234'
+      url: '/api/application/history/AHWR-7C72-8871'
     }
     const res = await server.inject(options)
 

--- a/test/integration/narrow/routes/api/application-history.test.js
+++ b/test/integration/narrow/routes/api/application-history.test.js
@@ -6,45 +6,35 @@ jest.mock('../../../../../app/azure-storage/application-status-repository')
 describe('Application history test', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
-    await server.start()
   })
 
-  afterEach(async () => {
-    await server.stop()
-  })
-  const reference = 'ABC-1234'
-  const url = `/api/application/history/${reference}`
-
-  describe(`GET ${url} route`, () => {
-    test('returns 200 with data', async () => {
-      getApplicationHistory.mockResolvedValue(
-        [{ ChangedOn: '2023-03-23T10:00:12.000Z', Payload: '{\n  "reference": "AHWR-7C72-8871",\n  "statusId": 91\n}', ChangedBy: 'Daniel Jones' },
-          { ChangedOn: '2023-03-24T09:30:00.000Z', Payload: '{\n  "reference": "AHWR-7C72-8871",\n  "statusId": 2\n}', ChangedBy: 'Daniel Jones' },
-          { ChangedOn: '2023-03-25T11:10:15:12.000Z', Payload: '{\n  "reference": "AHWR-7C72-8871",\n  "statusId": 10\n}', ChangedBy: 'Amanda Hassan' }]
-      )
-
-      const options = {
-        method: 'GET',
-        url: '/api/application/history/ABC-1234'
+  test('returns historyRecords', async () => {
+    const historyRecords = [
+      {
+        ChangedOn: '2023-03-23T10:00:12.000Z',
+        Payload: '{\n  "reference": "AHWR-7C72-8871",\n  "statusId": 91\n}',
+        ChangedBy: 'Daniel Jones'
+      },
+      {
+        ChangedOn: '2023-03-24T09:30:00.000Z',
+        Payload: '{\n  "reference": "AHWR-7C72-8871",\n  "statusId": 2\n}',
+        ChangedBy: 'Daniel Jones'
+      },
+      {
+        ChangedOn: '2023-03-25T11:10:15:12.000Z',
+        Payload: '{\n  "reference": "AHWR-7C72-8871",\n  "statusId": 10\n}',
+        ChangedBy: 'Amanda Hassan'
       }
-      const res = await server.inject(options)
-      expect(res.statusCode).toBe(200)
-      const $ = JSON.parse(res.payload)
-      expect($.historyRecords).not.toBeNull()
-      expect($.historyRecords.length).toBe(3)
-    })
+    ]
 
-    test('returns 200 with no data', async () => {
-      getApplicationHistory.mockResolvedValue(null)
+    getApplicationHistory.mockResolvedValue(historyRecords)
 
-      const options = {
-        method: 'GET',
-        url: '/api/application/history/ABC-1234'
-      }
-      const res = await server.inject(options)
-      expect(res.statusCode).toBe(200)
-      const $ = JSON.parse(res.payload)
-      expect($.historyRecords).toBeNull()
-    })
+    const options = {
+      method: 'GET',
+      url: '/api/application/history/ABC-1234'
+    }
+    const res = await server.inject(options)
+
+    expect(JSON.parse(res.payload)).toEqual({ historyRecords })
   })
 })

--- a/test/unit/app/azure-storage/application-status-repository.test.js
+++ b/test/unit/app/azure-storage/application-status-repository.test.js
@@ -4,32 +4,32 @@ import { queryEntitiesByPartitionKey } from '../../../../app/azure-storage/query
 jest.mock('../../../../app/azure-storage/query-entities')
 
 describe('Application Status Repository test', () => {
-  const reference = 'ABC-1234'
-
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
-  describe('getApplicationHistory ', () => {
-    test('getApplicationHistory - application history found', async () => {
-      queryEntitiesByPartitionKey.mockResolvedValue(
-        [{ ChangedOn: '2023-03-23T10:00:12.000Z', Payload: '{\n  "reference": "AHWR-7C72-8871",\n  "statusId": 91\n}', ChangedBy: 'Daniel Jones' },
-          { ChangedOn: '2023-03-24T09:30:00.000Z', Payload: '{\n  "reference": "AHWR-7C72-8871",\n  "statusId": 2\n}', ChangedBy: 'Daniel Jones' },
-          { ChangedOn: '2023-03-25T11:10:15:12.000Z', Payload: '{\n  "reference": "AHWR-7C72-8871",\n  "statusId": 10\n}', ChangedBy: 'Amanda Hassan' }])
+  test('getApplicationHistory - application history found', async () => {
+    const events = [
+      {
+        ChangedOn: '2023-03-23T10:00:12.000Z',
+        Payload: '{\n  "reference": "AHWR-7C72-8871",\n  "statusId": 91\n}',
+        ChangedBy: 'Daniel Jones'
+      },
+      {
+        ChangedOn: '2023-03-24T09:30:00.000Z',
+        Payload: '{\n  "reference": "AHWR-7C72-8871",\n  "statusId": 2\n}',
+        ChangedBy: 'Daniel Jones'
+      },
+      {
+        ChangedOn: '2023-03-25T11:10:15:12.000Z',
+        Payload: '{\n  "reference": "AHWR-7C72-8871",\n  "statusId": 10\n}',
+        ChangedBy: 'Amanda Hassan'
+      }
+    ]
+    queryEntitiesByPartitionKey.mockResolvedValueOnce(events)
 
-      const result = await getApplicationHistory(reference)
+    const result = await getApplicationHistory('AHWR-7C72-8871')
 
-      expect(queryEntitiesByPartitionKey).toHaveBeenCalledTimes(1)
-      expect(result).not.toBeNull()
-      expect(result.length).toBe(3)
-    })
-    test('getApplicationHistory - application history not found', async () => {
-      queryEntitiesByPartitionKey.mockResolvedValue([])
-
-      const result = await getApplicationHistory(reference)
-
-      expect(queryEntitiesByPartitionKey).toHaveBeenCalledTimes(1)
-      expect(result).toBeNull()
-    })
+    expect(result).toEqual(events)
   })
 })


### PR DESCRIPTION
No longer returning null if there are no history events, so the back-office doesn't need to convert them back to an array.