### PR TITLE
feat(AHWR-29): pass optional note on claim update

### DIFF
--- a/app/event-publisher/index.js
+++ b/app/event-publisher/index.js
@@ -17,7 +17,8 @@ export const raise = async (event) => {
           data: {
             reference: event.application.reference,
             statusId: event.application.statusId,
-            subStatus: event.application.subStatus
+            subStatus: event.application.subStatus,
+            note: event.note
           },
           raisedBy: event.raisedBy,
           raisedOn: event.raisedOn.toISOString()
@@ -64,7 +65,8 @@ export const raiseClaimEvents = async (event, sbi = 'none') => {
           data: {
             reference: event.claim.reference,
             applicationReference: event.claim.applicationReference,
-            statusId: event.claim.statusId
+            statusId: event.claim.statusId,
+            note: event.note
           },
           raisedBy: event.raisedBy,
           raisedOn: event.raisedOn.toISOString()

--- a/app/repositories/application-repository.js
+++ b/app/repositories/application-repository.js
@@ -164,7 +164,9 @@ export const setApplication = async (data) => {
   return result
 }
 
-export const updateApplicationByReference = async (data, publishEvent = true) => {
+export const updateApplicationByReference = async (dataWithNote, publishEvent = true) => {
+  const { note, ...data } = dataWithNote
+
   try {
     const application = await models.application.findOne({
       where: {
@@ -192,7 +194,8 @@ export const updateApplicationByReference = async (data, publishEvent = true) =>
           message: 'Application has been updated',
           application: updatedRecord.dataValues,
           raisedBy: updatedRecord.dataValues.updatedBy,
-          raisedOn: updatedRecord.dataValues.updatedAt
+          raisedOn: updatedRecord.dataValues.updatedAt,
+          note
         })
       }
     }

--- a/app/repositories/claim-repository.js
+++ b/app/repositories/claim-repository.js
@@ -69,15 +69,13 @@ export const updateClaimByReference = async (data, note, logger) => {
 
     const updatedRecord = result[1][0]
 
-    if (updatedRecord) {
-      await raiseClaimEvents({
-        message: 'Claim has been updated',
-        claim: updatedRecord.dataValues,
-        note,
-        raisedBy: updatedRecord.dataValues.updatedBy,
-        raisedOn: updatedRecord.dataValues.updatedAt
-      }, data.sbi)
-    }
+    await raiseClaimEvents({
+      message: 'Claim has been updated',
+      claim: updatedRecord.dataValues,
+      note,
+      raisedBy: updatedRecord.dataValues.updatedBy,
+      raisedOn: updatedRecord.dataValues.updatedAt
+    }, data.sbi)
   } catch (err) {
     logger.setBindings({ err })
     throw err

--- a/app/repositories/claim-repository.js
+++ b/app/repositories/claim-repository.js
@@ -50,16 +50,15 @@ export const setClaim = async (data) => {
   return result
 }
 
-export const updateClaimByReference = async (data) => {
+export const updateClaimByReference = async (data, note, logger) => {
   try {
     const claim = await models.claim.findOne({
       where: {
         reference: data.reference
-      },
-      returning: true
+      }
     })
 
-    if (claim?.dataValues?.statusId === data?.statusId) return claim
+    if (claim?.dataValues?.statusId === data.statusId) return claim
 
     const result = await models.claim.update(data, {
       where: {
@@ -68,23 +67,20 @@ export const updateClaimByReference = async (data) => {
       returning: true
     })
 
-    const updatedRows = result[0] // Number of affected rows
-    const updatedRecords = result[1] // Assuming this is the array of updated records
-    const sbi = data.sbi
+    const updatedRecord = result[1][0]
 
-    for (let i = 0; i < updatedRows; i++) {
-      const updatedRecord = updatedRecords[i]
+    if (updatedRecord) {
       await raiseClaimEvents({
         message: 'Claim has been updated',
         claim: updatedRecord.dataValues,
+        note,
         raisedBy: updatedRecord.dataValues.updatedBy,
         raisedOn: updatedRecord.dataValues.updatedAt
-      }, sbi)
+      }, data.sbi)
     }
-    return result
-  } catch (error) {
-    console.error('Error updating claim by reference:', error)
-    throw error
+  } catch (err) {
+    logger.setBindings({ err })
+    throw err
   }
 }
 

--- a/app/routes/api/application-history.js
+++ b/app/routes/api/application-history.js
@@ -13,6 +13,7 @@ export const applicationHistoryHandlers = [
       },
       handler: async (request, h) => {
         const historyRecords = await getApplicationHistory(request.params.ref)
+        historyRecords.sort((a, b) => new Date(a.ChangedOn) - new Date(b.ChangedOn))
         return h.response({ historyRecords }).code(200)
       }
     }

--- a/app/routes/api/applications.js
+++ b/app/routes/api/applications.js
@@ -104,7 +104,7 @@ export const applicationHandlers = [{
     validate: {
       payload: joi.object({
         approved: joi.boolean().required(),
-        reference: joi.string().valid(),
+        reference: joi.string().required(),
         user: joi.string().required(),
         note: joi.string()
       }),

--- a/app/routes/api/claim.js
+++ b/app/routes/api/claim.js
@@ -338,8 +338,9 @@ export const claimHandlers = [
       validate: {
         payload: Joi.object({
           reference: Joi.string().valid().required(),
-          status: Joi.number().valid(5, 9, 10).required(),
-          user: Joi.string().required()
+          status: Joi.number().required(),
+          user: Joi.string().required(),
+          note: Joi.string().allow('')
         }),
         failAction: async (request, h, err) => {
           request.logger.setBindings({ err })
@@ -348,7 +349,7 @@ export const claimHandlers = [
         }
       },
       handler: async (request, h) => {
-        const { reference, status } = request.payload
+        const { reference, status, note } = request.payload
 
         request.logger.setBindings({
           reference,
@@ -388,7 +389,16 @@ export const claimHandlers = [
           )
         }
 
-        await updateClaimByReference({ reference, statusId: status, updatedBy: request.payload.user, sbi })
+        await updateClaimByReference(
+          {
+            reference,
+            statusId: status,
+            updatedBy: request.payload.user,
+            sbi
+          },
+          note,
+          request.logger
+        )
 
         return h.response().code(200)
       }

--- a/app/routes/api/claim.js
+++ b/app/routes/api/claim.js
@@ -340,7 +340,7 @@ export const claimHandlers = [
           reference: Joi.string().valid().required(),
           status: Joi.number().required(),
           user: Joi.string().required(),
-          note: Joi.string().allow('')
+          note: Joi.string()
         }),
         failAction: async (request, h, err) => {
           request.logger.setBindings({ err })

--- a/app/routes/api/stage-execution.js
+++ b/app/routes/api/stage-execution.js
@@ -95,10 +95,10 @@ export const stageExecutionHandlers = [{
         if (request.payload.claimOrApplication === 'claim') {
           const mainApplication = await getApplication(applicationOrClaim.dataValues.applicationReference)
           const sbi = mainApplication?.dataValues?.data?.organisation?.sbi
+          const note = null
           // note that even though it using request.payload.applicationReference
           // it can actually be the claim reference which is passed in the request
           // see AHWR-454 for further details
-          const note = null
           await updateClaimByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy, sbi }, note, request.logger)
         } else {
           await updateApplicationByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy })

--- a/app/routes/api/stage-execution.js
+++ b/app/routes/api/stage-execution.js
@@ -98,7 +98,8 @@ export const stageExecutionHandlers = [{
           // note that even though it using request.payload.applicationReference
           // it can actually be the claim reference which is passed in the request
           // see AHWR-454 for further details
-          await updateClaimByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy, sbi })
+          const note = null
+          await updateClaimByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy, sbi }, note, request.logger)
         } else {
           await updateApplicationByReference({ reference: request.payload.applicationReference, statusId, updatedBy: request.payload.executedBy })
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Application manager for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-application",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/api/applications.test.js
+++ b/test/integration/narrow/routes/api/applications.test.js
@@ -13,12 +13,8 @@ const data = { organisation: { sbi: '1231' }, whichReview: 'sheep' }
 describe('Applications test', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
-    await server.start()
   })
 
-  afterEach(async () => {
-    await server.stop()
-  })
   const reference = 'ABC-1234'
 
   describe('GET /api/application/get route', () => {
@@ -171,8 +167,7 @@ describe('Applications test', () => {
     test.each([
       { status: 'abc', user: null },
       { status: 'abc', user: 0 },
-      { status: 5000, user: 'test' },
-      { status: 9, user: 'test' }
+      { status: 5000, user: 'test' }
     ])('returns 400 with error message for invalid input', async ({ status, user }) => {
       const options = {
         method,

--- a/test/integration/narrow/routes/api/stage-execution.test.js
+++ b/test/integration/narrow/routes/api/stage-execution.test.js
@@ -35,11 +35,9 @@ const mockResponse = {
 describe('Stage execution test', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
-    await server.start()
   })
 
   afterEach(async () => {
-    await server.stop()
     resetAllWhenMocks()
   })
   const url = '/api/stageexecution'
@@ -141,7 +139,12 @@ describe('Stage execution test', () => {
       expect(res.statusCode).toBe(200)
       expect(set).toHaveBeenCalledTimes(1)
       expect(set).toHaveBeenCalledWith({ ...data, claimOrApplication: 'claim', action: { action }, executedAt: expect.any(Date) })
-      expect(updateClaimByReference).toHaveBeenCalledWith({ reference: data.applicationReference, statusId: expectedStatusId, updatedBy: data.executedBy })
+      expect(updateClaimByReference)
+        .toHaveBeenCalledWith(
+          { reference: data.applicationReference, statusId: expectedStatusId, updatedBy: data.executedBy },
+          null,
+          expect.any(Object)
+        )
       expect(res.result).toEqual({ ...mockResponse, claimOrApplication: 'claim', action: { action } })
     })
     test('returns 200 when an application is Recommended to pay', async () => {

--- a/test/unit/app/repository/claim-repository.test.js
+++ b/test/unit/app/repository/claim-repository.test.js
@@ -545,52 +545,6 @@ describe('Claim repository test', () => {
       }])
     })
 
-    test('Update record for data by reference - 0 records updated', async () => {
-      process.env.APPINSIGHTS_CLOUDROLE = 'cloud_role'
-      const reference = 'AHWR-7C72-8871'
-
-      when(buildData.models.claim.update)
-        .calledWith(
-          {
-            reference,
-            statusId: 3,
-            updatedBy: 'admin'
-          },
-          {
-            where: {
-              reference
-            },
-            returning: true
-          })
-        .mockResolvedValue([
-          0,
-          []
-        ])
-
-      const note = null
-      const logger = { setBindings: jest.fn() }
-      await updateClaimByReference({
-        reference,
-        statusId: 3,
-        updatedBy: 'admin'
-      }, note, logger)
-
-      expect(buildData.models.claim.update).toHaveBeenCalledTimes(1)
-      expect(buildData.models.claim.update).toHaveBeenCalledWith(
-        {
-          reference,
-          statusId: 3,
-          updatedBy: 'admin'
-        },
-        {
-          where: {
-            reference
-          },
-          returning: true
-        }
-      )
-      expect(MOCK_SEND_EVENTS).toHaveBeenCalledTimes(0)
-    })
     test('Update status of a claim which is holding same status', async () => {
       const reference = 'AHWR-7C72-8871'
 

--- a/test/unit/app/repository/claim-repository.test.js
+++ b/test/unit/app/repository/claim-repository.test.js
@@ -321,7 +321,7 @@ describe('Claim repository test', () => {
       statusId: 11,
       type: 'R',
       createdAt: '2024-02-01T07:24:29.224Z',
-      updatedAt: '2024-02-01T08:02:30.356Z',
+      updatedAt: new Date(),
       createdBy: 'admin',
       updatedBy: null,
       status: {
@@ -329,12 +329,13 @@ describe('Claim repository test', () => {
       }
     }
 
-    when(buildData.models.claim.update).mockResolvedValue(claim)
+    when(buildData.models.claim.update).mockResolvedValue([0, [{ dataValues: claim }]])
 
-    const result = await updateClaimByReference(claim)
+    const note = 'note'
+    const logger = { setBindings: jest.fn() }
+    await updateClaimByReference(claim, note, logger)
 
     expect(buildData.models.claim.update).toHaveBeenCalledTimes(1)
-    expect(claim).toEqual(result)
   })
   test('Get all claimed claims', async () => {
     const claim = {
@@ -412,35 +413,39 @@ describe('Claim repository test', () => {
     }
 
     test('should update an application by reference successfully', async () => {
-      const updateResult = [1, [{ dataValues: { ...mockData, updatedAt: new Date(), updatedBy: 'admin' } }]] // Simulate one record updated
+      const updateResult = [
+        1,
+        [{ dataValues: { ...mockData, updatedAt: new Date(), updatedBy: 'admin' } }]
+      ]
 
       buildData.models.claim.update.mockResolvedValue(updateResult)
       MOCK_SEND_EVENTS.mockResolvedValue(null)
 
-      const result = await updateClaimByReference(mockData)
+      const note = null
+      const logger = { setBindings: jest.fn() }
+      await updateClaimByReference(mockData, note, logger)
 
       expect(buildData.models.claim.update).toHaveBeenCalledWith(mockData, {
         where: { reference: mockData.reference },
         returning: true
       })
       expect(MOCK_SEND_EVENTS).toHaveBeenCalledTimes(1)
-      expect(result).toEqual(updateResult)
     })
 
     test('should handle failure to update an application by reference', async () => {
-      buildData.models.claim.update.mockRejectedValue(new Error('Update failed'))
-
-      await expect(updateClaimByReference(mockData)).rejects.toThrow('Update failed')
+      buildData.models.claim.update.mockRejectedValueOnce('Update failed')
+      const logger = { setBindings: jest.fn() }
+      const note = null
+      await expect(updateClaimByReference(mockData, note, logger)).rejects.toBe('Update failed')
       expect(MOCK_SEND_EVENTS).not.toHaveBeenCalled()
     })
   })
 
   describe('updateByReference', () => {
-    test('Update record for data by reference - 2 records updated', async () => {
+    test('Update record for data by reference - record updated', async () => {
       process.env.APPINSIGHTS_CLOUDROLE = 'cloud_role'
       const mockNow = new Date()
       const reference = 'AHWR-7C72-8871'
-
       when(buildData.models.claim.update)
         .calledWith(
           {
@@ -455,27 +460,12 @@ describe('Claim repository test', () => {
             returning: true
           })
         .mockResolvedValue([
-          2,
+          1,
           [
             {
               dataValues: {
                 id: '180c5d84-cc3f-4e50-9519-8b5a1fc83ac0',
-                reference: 'AHWR-7C72-8871',
-                statusId: 3,
-                data: {
-                  organisation: {
-                    sbi: 'none',
-                    email: 'business@email.com'
-                  }
-                },
-                updatedBy: 'admin',
-                updatedAt: mockNow
-              }
-            },
-            {
-              dataValues: {
-                id: '180c5d84-cc3f-4e50-9519-8b5a1fc83ac0',
-                reference: 'AHWR-7C72-8872',
+                reference,
                 statusId: 3,
                 data: {
                   organisation: {
@@ -490,11 +480,13 @@ describe('Claim repository test', () => {
           ]
         ])
 
+      const note = 'admin override'
+      const logger = { setBindings: jest.fn() }
       await updateClaimByReference({
         reference,
         statusId: 3,
         updatedBy: 'admin'
-      })
+      }, note, logger)
 
       expect(buildData.models.claim.update).toHaveBeenCalledTimes(1)
       expect(buildData.models.claim.update).toHaveBeenCalledWith(
@@ -510,7 +502,7 @@ describe('Claim repository test', () => {
           returning: true
         }
       )
-      expect(MOCK_SEND_EVENTS).toHaveBeenCalledTimes(2)
+      expect(MOCK_SEND_EVENTS).toHaveBeenCalledTimes(1)
       expect(MOCK_SEND_EVENTS).toHaveBeenNthCalledWith(1, [{
         name: 'application-status-event',
         properties: {
@@ -523,8 +515,9 @@ describe('Claim repository test', () => {
             type: 'status-updated',
             message: 'Claim has been updated',
             data: {
-              reference: 'AHWR-7C72-8871',
-              statusId: 3
+              reference,
+              statusId: 3,
+              note
             },
             raisedBy: 'admin',
             raisedOn: mockNow.toISOString()
@@ -542,7 +535,7 @@ describe('Claim repository test', () => {
             type: 'application:status-updated:3',
             message: 'Claim has been updated',
             data: {
-              reference: 'AHWR-7C72-8871',
+              reference,
               statusId: 3
             },
             raisedBy: 'admin',
@@ -550,48 +543,6 @@ describe('Claim repository test', () => {
           }
         }
       }])
-      expect(MOCK_SEND_EVENTS).toHaveBeenNthCalledWith(2, [
-        {
-          name: 'application-status-event',
-          properties: {
-            id: '180c5d84-cc3f-4e50-9519-8b5a1fc83ac0',
-            sbi: 'none',
-            cph: 'n/a',
-            checkpoint: 'cloud_role',
-            status: 'success',
-            action: {
-              type: 'status-updated',
-              message: 'Claim has been updated',
-              data: {
-                reference: 'AHWR-7C72-8872',
-                statusId: 3
-              },
-              raisedBy: 'admin',
-              raisedOn: mockNow.toISOString()
-            }
-          }
-        },
-        {
-          name: 'send-session-event',
-          properties: {
-            id: '180c5d84-cc3f-4e50-9519-8b5a1fc83ac0',
-            sbi: 'none',
-            cph: 'n/a',
-            checkpoint: 'cloud_role',
-            status: 'success',
-            action: {
-              type: 'application:status-updated:3',
-              message: 'Claim has been updated',
-              data: {
-                reference: 'AHWR-7C72-8872',
-                statusId: 3
-              },
-              raisedBy: 'admin',
-              raisedOn: mockNow.toISOString()
-            }
-          }
-        }
-      ])
     })
 
     test('Update record for data by reference - 0 records updated', async () => {
@@ -616,11 +567,13 @@ describe('Claim repository test', () => {
           []
         ])
 
+      const note = null
+      const logger = { setBindings: jest.fn() }
       await updateClaimByReference({
         reference,
         statusId: 3,
         updatedBy: 'admin'
-      })
+      }, note, logger)
 
       expect(buildData.models.claim.update).toHaveBeenCalledTimes(1)
       expect(buildData.models.claim.update).toHaveBeenCalledWith(
@@ -648,16 +601,20 @@ describe('Claim repository test', () => {
           },
           returning: true
         })
-        .mockResolvedValue({ dataValues: { statusId: 3 } })
+        .mockResolvedValue([
+          1,
+          [{ dataValues: { statusId: 3, updatedAt: new Date() } }]
+        ])
 
-      const result = await updateClaimByReference({
+      const note = null
+      const logger = { setBindings: jest.fn() }
+      await updateClaimByReference({
         reference,
         statusId: 3,
         updatedBy: 'admin'
-      })
+      }, note, logger)
 
       expect(buildData.models.claim.findOne).toHaveBeenCalledTimes(1)
-      expect(result).toEqual({ dataValues: { statusId: 3 } })
     })
 
     test('Update record for data by reference - throw exception', async () => {
@@ -677,29 +634,15 @@ describe('Claim repository test', () => {
             },
             returning: true
           })
-        .mockResolvedValue(new Error('Something failed'))
+        .mockRejectedValue('Something failed')
 
-      await updateClaimByReference({
+      const note = null
+      const logger = { setBindings: jest.fn() }
+      await expect(updateClaimByReference({
         reference,
         statusId: 3,
         updatedBy: 'admin'
-      })
-
-      expect(buildData.models.claim.update).toHaveBeenCalledTimes(1)
-      expect(buildData.models.claim.update).toHaveBeenCalledWith(
-        {
-          reference,
-          statusId: 3,
-          updatedBy: 'admin'
-        },
-        {
-          where: {
-            reference
-          },
-          returning: true
-        }
-      )
-      expect(MOCK_SEND_EVENTS).toHaveBeenCalledTimes(0)
+      }, note, logger)).rejects.toBe('Something failed')
     })
   })
   describe('Search Claim', () => {


### PR DESCRIPTION
**Enables:** https://github.com/DEFRA/ffc-ahwr-backoffice/pull/265

Note can now be passed for claim and application updates and will be added to the emitted history event.

History response is now sorted on the api rather than the client. Though it's hard coded to be by date ascending (as it was on the clients).