### PR TITLE
feat(AHWR): new claims data endpoint

### DIFF
--- a/app/logger.js
+++ b/app/logger.js
@@ -47,6 +47,7 @@ export const logger = {
       res,
       err
     },
-    ...(process.env.USE_PRETTY_PRINT === 'true' && { transport })
+    ...(process.env.USE_PRETTY_PRINT === 'true' && { transport }),
+    redact: ['payload.vetsName']
   }
 }

--- a/app/logger.js
+++ b/app/logger.js
@@ -48,6 +48,6 @@ export const logger = {
       err
     },
     ...(process.env.USE_PRETTY_PRINT === 'true' && { transport }),
-    redact: ['payload.vetsName']
+    redact: ['payload.vetsName', 'payload.vetRCVSNumber']
   }
 }

--- a/app/repositories/claim.js
+++ b/app/repositories/claim.js
@@ -1,0 +1,36 @@
+import { Sequelize } from 'sequelize'
+import { buildData } from '../data/index.js'
+import { raiseClaimEvents } from '../event-publisher/index.js'
+
+export const getClaim = async (reference) => {
+  const claim = await buildData.models.claim.findOne({ where: { reference } })
+  return claim === null ? claim : claim.dataValues
+}
+
+export const patchClaimData = async (reference, key, value, note) => {
+  const data = Sequelize.fn(
+    'jsonb_set',
+    Sequelize.col('data'),
+    Sequelize.literal(`'{${key}}'`),
+    Sequelize.literal(`'${JSON.stringify(value)}'`)
+  )
+
+  // eslint-disable-next-line no-unused-vars
+  const [_, updates] = await buildData.models.claim.update(
+    { data },
+    {
+      where: { reference },
+      returning: true
+    }
+  )
+
+  const [updatedRecord] = updates
+
+  await raiseClaimEvents({
+    message: 'Claim has been updated',
+    claim: updatedRecord.dataValues,
+    note,
+    raisedBy: updatedRecord.dataValues.updatedBy,
+    raisedOn: updatedRecord.dataValues.updatedOn
+  })
+}

--- a/app/routes/api/claims.js
+++ b/app/routes/api/claims.js
@@ -1,0 +1,49 @@
+import joi from 'joi'
+import { getClaim, patchClaimData } from '../../repositories/claim.js'
+
+export const claimsHandlers = [
+  {
+    method: 'patch',
+    path: '/api/claims/{reference}/data',
+    options: {
+      validate: {
+        params: joi.object({
+          reference: joi.string()
+        }),
+        payload: joi.object({
+          vetsName: joi.string(),
+          dateOfVisit: joi.date(),
+          vetRCVSNumber: joi.string().pattern(/^\d{6}[\dX]$/i),
+          note: joi.string().required()
+        }).or('vetsName', 'dateOfVisit', 'vetRCVSNumber')
+          .required(),
+        failAction: async (request, h, err) => {
+          request.logger.setBindings({ err })
+          return h.response({ err }).code(400).takeover()
+        }
+      }
+    },
+    handler: async (request, h) => {
+      const { reference } = request.params
+      const { note, ...dataPayload } = request.payload
+
+      request.logger.setBindings({ reference, dataPayload })
+
+      const claim = await getClaim(reference)
+      if (claim === null) {
+        return h.response('Not Found').code(404).takeover()
+      }
+
+      const [key, value] = Object.entries(dataPayload)
+        .filter(([key, value]) => value !== claim.data[key])
+        .flat()
+
+      if (key === undefined && value === undefined) {
+        return h.response().code(204)
+      }
+
+      await patchClaimData(reference, key, value, note)
+      return h.response().code(204)
+    }
+  }
+]

--- a/app/server.js
+++ b/app/server.js
@@ -9,6 +9,7 @@ import { stageConfiguationHandlers } from './routes/api/stage-configuration.js'
 import { stageExecutionHandlers } from './routes/api/stage-execution.js'
 import { applicationEventsHandlers } from './routes/api/application-events.js'
 import { claimHandlers } from './routes/api/claim.js'
+import { claimsHandlers } from './routes/api/claims.js'
 import { holidayHandlers } from './routes/api/holidays.js'
 import { contactHistoryHandlers } from './routes/api/contact-history.js'
 
@@ -25,6 +26,7 @@ server.route([
   ...stageExecutionHandlers,
   ...applicationEventsHandlers,
   ...claimHandlers,
+  ...claimsHandlers,
   ...holidayHandlers,
   ...contactHistoryHandlers,
   ...latestContactDetailsHandlers

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-application",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/data-tables": "^13.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-application",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Application manager for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-application",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/api/claims.test.js
+++ b/test/integration/narrow/routes/api/claims.test.js
@@ -88,7 +88,7 @@ test('patch /claims/{ref}/data missing claim', async () => {
   expect(raiseClaimEvents.mock.calls).toEqual([])
 })
 
-test('patch /claims/{ref}/data invalid payload', async () => {
+test('patch /claims/{ref}/data invalid payload: missing note', async () => {
   const res = await server.inject({
     method: 'patch',
     url: '/api/claims/FUSH-BAAH-1234/data',
@@ -100,4 +100,19 @@ test('patch /claims/{ref}/data invalid payload', async () => {
   expect(res.statusCode).toBe(400)
   const { err } = JSON.parse(res.payload)
   expect(err.details[0].message).toBe('"note" is required')
+})
+
+test('patch /claims/{ref}/data invalid payload: missing data property', async () => {
+  const res = await server.inject({
+    method: 'patch',
+    url: '/api/claims/FUSH-BAAH-1234/data',
+    payload: {
+      note: 'no data properties'
+    }
+  })
+
+  expect(res.statusCode).toBe(400)
+  const { err } = JSON.parse(res.payload)
+  expect(err.details[0].message)
+    .toBe('"value" must contain at least one of [vetsName, dateOfVisit, vetRCVSNumber]')
 })

--- a/test/integration/narrow/routes/api/claims.test.js
+++ b/test/integration/narrow/routes/api/claims.test.js
@@ -1,0 +1,103 @@
+import { server } from '../../../../../app/server'
+import { buildData } from '../../../../../app/data'
+import { raiseClaimEvents } from '../../../../../app/event-publisher'
+
+jest.mock('../../../../../app/event-publisher')
+
+beforeEach(jest.resetAllMocks)
+
+test('patch /claims/{ref}/data update data property', async () => {
+  jest.spyOn(buildData.models.claim, 'findOne')
+    .mockResolvedValueOnce({
+      dataValues: {
+        reference: 'FUSH-BAAH-1234',
+        data: {
+          vetsName: 'Jane Oldman'
+        }
+      }
+    })
+
+  const claim = {
+    updatedBy: 'me',
+    updatedOn: '2025-03-20T12:12:28.590Z'
+  }
+
+  jest.spyOn(buildData.models.claim, 'update')
+    .mockResolvedValueOnce([1, [{ dataValues: claim }]])
+
+  const note = "update vet's name"
+  const res = await server.inject({
+    method: 'patch',
+    url: '/api/claims/FUSH-BAAH-1234/data',
+    payload: {
+      vetsName: 'Barry Newman',
+      note
+    }
+  })
+
+  expect(res.statusCode).toBe(204)
+  expect(raiseClaimEvents.mock.calls).toEqual([
+    [{
+      claim,
+      message: 'Claim has been updated',
+      note,
+      raisedBy: claim.updatedBy,
+      raisedOn: claim.updatedOn
+    }]
+  ])
+})
+
+test('patch /claims/{ref}/data data property same as existing', async () => {
+  jest.spyOn(buildData.models.claim, 'findOne')
+    .mockResolvedValueOnce({
+      dataValues: {
+        reference: 'FUSH-BAAH-1234',
+        data: {
+          vetsName: 'Fred Already'
+        }
+      }
+    })
+
+  const res = await server.inject({
+    method: 'patch',
+    url: '/api/claims/FUSH-BAAH-1234/data',
+    payload: {
+      vetsName: 'Fred Already',
+      note: 'same as before'
+    }
+  })
+
+  expect(res.statusCode).toBe(204)
+  expect(raiseClaimEvents.mock.calls).toEqual([])
+})
+
+test('patch /claims/{ref}/data missing claim', async () => {
+  jest.spyOn(buildData.models.claim, 'findOne')
+    .mockResolvedValueOnce(null)
+
+  const res = await server.inject({
+    method: 'patch',
+    url: '/api/claims/FUSH-BAAH-1234/data',
+    payload: {
+      vetRCVSNumber: '1234567',
+      note: 'note'
+    }
+  })
+
+  expect(res.statusCode).toBe(404)
+  expect(raiseClaimEvents.mock.calls).toEqual([])
+})
+
+test('patch /claims/{ref}/data invalid payload', async () => {
+  const res = await server.inject({
+    method: 'patch',
+    url: '/api/claims/FUSH-BAAH-1234/data',
+    payload: {
+      dateOfVisit: '2025-03-20'
+    }
+  })
+
+  expect(res.statusCode).toBe(400)
+  const { err } = JSON.parse(res.payload)
+  expect(err.details[0].message).toBe('"note" is required')
+})


### PR DESCRIPTION
Endpoint for patching the JSONB data column for claims

Example curl for testing:

for claim: *FUSH-T5FJ-1F8Y*

```
curl -X 'PATCH' \
  'http://localhost:3001/api/claims/FUSH-T5FJ-1F8Y/data' \
  -H 'accept: application/json' \
  -H 'content-type: application/json' \
  --data-binary @- << EOF
{
  "vetsName": "Barry Ho",
  "note": "changing his name"
}
EOF
```

Endpoint specifically for patching the data blob as the behaviour is quite different to other top level updates.

Only designed to accept a single property update, one of vetsName, vetRCVSNumber or visitDate.